### PR TITLE
Fix WFLY-9788

### DIFF
--- a/ejb/src/main/java/org/wildfly/httpclient/ejb/HttpEJBInvocationBuilder.java
+++ b/ejb/src/main/java/org/wildfly/httpclient/ejb/HttpEJBInvocationBuilder.java
@@ -18,11 +18,14 @@
 
 package org.wildfly.httpclient.ejb;
 
-import java.lang.reflect.Method;
-
 import io.undertow.client.ClientRequest;
 import io.undertow.util.Headers;
 import io.undertow.util.Methods;
+
+import java.io.UnsupportedEncodingException;
+import java.lang.reflect.Method;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 
 /**
@@ -172,6 +175,7 @@ class HttpEJBInvocationBuilder {
         sb.append(Boolean.toString(cancelIfRunning));
         return sb.toString();
     }
+
     /**
      * Constructs an EJB invocation path
      *
@@ -196,9 +200,9 @@ class HttpEJBInvocationBuilder {
         sb.append(view);
         sb.append("/");
         sb.append(method.getName());
-        for (Class<?> param : method.getParameterTypes()) {
+        for (final Class<?> param : method.getParameterTypes()) {
             sb.append("/");
-            sb.append(param.getName());
+            sb.append(encodeUrlPart(param.getName()));
         }
         return sb.toString();
     }
@@ -206,7 +210,7 @@ class HttpEJBInvocationBuilder {
     private void buildBeanPath(String mountPoint, String type, String appName, String moduleName, String distinctName, String beanName, StringBuilder sb) {
         buildModulePath(mountPoint, type, appName, moduleName, distinctName, sb);
         sb.append("/");
-        sb.append(beanName);
+        sb.append(encodeUrlPart(beanName));
     }
 
     private void buildModulePath(String mountPoint, String type, String appName, String moduleName, String distinctName, StringBuilder sb) {
@@ -221,19 +225,27 @@ class HttpEJBInvocationBuilder {
         if (appName == null || appName.isEmpty()) {
             sb.append("-");
         } else {
-            sb.append(appName);
+            sb.append(encodeUrlPart(appName));
         }
         sb.append("/");
         if (moduleName == null || moduleName.isEmpty()) {
             sb.append("-");
         } else {
-            sb.append(moduleName);
+            sb.append(encodeUrlPart(moduleName));
         }
         sb.append("/");
         if (distinctName == null || distinctName.isEmpty()) {
             sb.append("-");
         } else {
-            sb.append(distinctName);
+            sb.append(encodeUrlPart(distinctName));
+        }
+    }
+
+    private static String encodeUrlPart(final String part) {
+        try {
+            return URLEncoder.encode(part, StandardCharsets.UTF_8.name());
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
         }
     }
 

--- a/ejb/src/test/java/org/wildfly/httpclient/ejb/EchoRemote.java
+++ b/ejb/src/test/java/org/wildfly/httpclient/ejb/EchoRemote.java
@@ -29,6 +29,8 @@ public interface EchoRemote {
 
     String echo(String msg) throws Exception;
 
+    String[] echo(String[] msgs);
+
     String message() throws Exception;
 
     Future<String> asyncMessage();

--- a/ejb/src/test/java/org/wildfly/httpclient/ejb/SimpleEJBInterceptor.java
+++ b/ejb/src/test/java/org/wildfly/httpclient/ejb/SimpleEJBInterceptor.java
@@ -1,0 +1,48 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ *
+ */
+
+package org.wildfly.httpclient.ejb;
+
+import org.jboss.ejb.client.EJBClientInterceptor;
+import org.jboss.ejb.client.EJBClientInvocationContext;
+
+/**
+ * A {@link EJBClientInterceptor} which puts a key/value in the {@link EJBClientInvocationContext#getContextData() context data}
+ * during {@link #handleInvocation(EJBClientInvocationContext) invocation}
+ */
+public class SimpleEJBInterceptor implements EJBClientInterceptor {
+
+    static final String KEY = "some integer";
+    static final Integer VALUE = new Integer(42);
+
+    @Override
+    public void handleInvocation(final EJBClientInvocationContext context) throws Exception {
+        context.getContextData().put(KEY, VALUE);
+        context.sendRequest();
+    }
+
+    @Override
+    public Object handleInvocationResult(final EJBClientInvocationContext context) throws Exception {
+        return context.getResult();
+    }
+}


### PR DESCRIPTION
The commit here fixes the issue reported in https://issues.jboss.org/browse/WFLY-9788.

The commit not just URL encodes the method param type(s) part but even the (user configurable) app-name, module-name and other similar parts, which too have a potential of containing characters that might need URL encoding.

The commit consists of a testcase to reproduce and verify the issue.
