### PR TITLE
WEJBHTTP-24 Cannot invoke EJB over HTTP on JDK 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <version.javax.ejb.api>1.0.0.Final</version.javax.ejb.api>
         <version.javax.transactions>1.0.1.Final</version.javax.transactions>
         <version.org.wildfly.checkstyle-config>1.0.4.Final</version.org.wildfly.checkstyle-config>
-        <version.org.jboss.marshalling>2.0.0.Final</version.org.jboss.marshalling>
+        <version.org.jboss.marshalling>2.0.6.Final</version.org.jboss.marshalling>
         <version.org.jboss.modules>1.6.0.Final</version.org.jboss.modules>
         <version.org.wildfly.client-config>1.0.0.Final</version.org.wildfly.client-config>
         <version.org.wildfly.common>1.2.0.Final</version.org.wildfly.common>
@@ -149,6 +149,12 @@
             <dependency>
                 <groupId>org.jboss.marshalling</groupId>
                 <artifactId>jboss-marshalling-river</artifactId>
+                <version>${version.org.jboss.marshalling}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.marshalling</groupId>
+                <artifactId>jboss-marshalling</artifactId>
                 <version>${version.org.jboss.marshalling}</version>
             </dependency>
 


### PR DESCRIPTION
Upgrade jboss-marshalling from 2.0.1 to 2.0.6 to address issue WEJBHTTP-24, WFLY-11720 and JBEAP-16394.  Also added explicit dependency declaration for jboss-marshalling to make sure it's consistent with jboss-marshalling-river.