### PR TITLE
WEJBHTTP-28 Throw AuthenticationException instead of IOException on 401

### DIFF
--- a/common/src/main/java/org/wildfly/httpclient/common/HttpClientMessages.java
+++ b/common/src/main/java/org/wildfly/httpclient/common/HttpClientMessages.java
@@ -19,6 +19,7 @@
 package org.wildfly.httpclient.common;
 
 import java.io.IOException;
+import javax.naming.AuthenticationException;
 
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
@@ -69,4 +70,7 @@ interface HttpClientMessages extends BasicLogger {
 
     @Message(id = 12, value = "Attempted to do blocking IO from the IO thread. This is prohibited as it may result in deadlocks")
     IllegalStateException blockingIoFromIOThread();
+
+    @Message(id = 13, value = "Authentication failed (full response %s)")
+    AuthenticationException authenticationFailed(ClientResponse response);
 }

--- a/common/src/test/java/org/wildfly/httpclient/common/AuthenticationExceptionTestCase.java
+++ b/common/src/test/java/org/wildfly/httpclient/common/AuthenticationExceptionTestCase.java
@@ -1,0 +1,96 @@
+package org.wildfly.httpclient.common;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import javax.naming.AuthenticationException;
+
+import io.undertow.client.ClientRequest;
+import io.undertow.client.ClientResponse;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.Headers;
+import io.undertow.util.Methods;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.security.auth.client.AuthenticationConfiguration;
+
+/**
+ * Client should throw AuthenticationException rather than general IOException when authentication fails.
+ *
+ * Legacy behavior can be enforced by setting system property "org.wildfly.httpclient.io-exception-on-failed-auth"
+ * to "true".
+ */
+@SuppressWarnings({"Convert2Lambda", "Anonymous2MethodRef"})
+@RunWith(HTTPTestServer.class)
+public class AuthenticationExceptionTestCase {
+
+    @Before
+    public void setUp() {
+        HTTPTestServer.registerPathHandler("/", new HttpHandler() {
+            @Override
+            public void handleRequest(HttpServerExchange exchange) {
+                // pretend authentication failure
+                exchange.setStatusCode(401);
+                exchange.getResponseHeaders().add(Headers.CONTENT_TYPE, "text/html");
+            }
+        });
+    }
+
+    @Test
+    public void testAuthenticationExceptionOnAuthenticationFailure() throws URISyntaxException {
+        System.clearProperty("org.wildfly.httpclient.io-exception-on-failed-auth");
+        assertRequestException(AuthenticationException.class);
+    }
+
+    @Test
+    public void testLegacyGeneralExceptionOnAuthenticationFailure() throws URISyntaxException {
+        System.setProperty("org.wildfly.httpclient.io-exception-on-failed-auth", "true");
+        assertRequestException(IOException.class);
+    }
+
+    private void assertRequestException(Class<? extends Exception> exceptionType) throws URISyntaxException {
+        ClientRequest request = new ClientRequest().setMethod(Methods.GET).setPath("/");
+        CompletableFuture<ClientResponse> responseFuture = doClientRequest(request);
+
+        try {
+            responseFuture.join();
+            Assert.fail("CompletionException is expected");
+        } catch (CompletionException e) {
+            Throwable cause = e.getCause();
+            Assert.assertNotNull(cause);
+            String expectedTypeMessage = String.format("Expected %s, got %s",
+                    exceptionType.getSimpleName(),
+                    cause.getClass().getSimpleName());
+            Assert.assertEquals(expectedTypeMessage, cause.getClass(), exceptionType);
+        }
+    }
+
+    private CompletableFuture<ClientResponse> doClientRequest(ClientRequest request) throws URISyntaxException {
+        ClientAuthUtils.setupBasicAuth(request, new URI(HTTPTestServer.getDefaultServerURL() + request.getPath()));
+
+        CompletableFuture<ClientResponse> responseFuture = new CompletableFuture<>();
+        HttpTargetContext context = WildflyHttpContext.getCurrent().getTargetContext(new URI(HTTPTestServer.getDefaultServerURL()));
+        context.sendRequest(request, null, AuthenticationConfiguration.empty(), null,
+                new HttpTargetContext.HttpResultHandler() {
+                    @Override
+                    public void handleResult(InputStream result, ClientResponse response, Closeable doneCallback) {
+                        responseFuture.complete(response);
+                    }
+                }, new HttpTargetContext.HttpFailureHandler() {
+                    @Override
+                    public void handleFailure(Throwable throwable) {
+                        responseFuture.completeExceptionally(throwable);
+                    }
+                },
+                null, null, true);
+        return responseFuture;
+    }
+
+}


### PR DESCRIPTION
Component: https://issues.jboss.org/browse/WEJBHTTP-28
Wildfly: https://issues.jboss.org/browse/WFLY-12444
EAP 7.3: https://issues.jboss.org/browse/JBEAP-17353
EAP 7.2: https://issues.jboss.org/browse/JBEAP-17721

HTTP client should throw AuthenticationException rather than IOException when it receives 401 response.

`org.wildfly.httpclient.io-exception-on-failed-auth` system property is introduced to enforce the original behavior.