### PR TITLE
[WEJBHTTP-42] Upgrade WildFly Elytron to 1.12.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <version.org.wildfly.client-config>1.0.1.Final</version.org.wildfly.client-config>
         <version.org.wildfly.common>1.5.4.Final</version.org.wildfly.common>
         <version.org.wildfly.naming.client>1.0.12.Final</version.org.wildfly.naming.client>
-        <version.org.wildfly.elytron>1.11.4.Final</version.org.wildfly.elytron>
+        <version.org.wildfly.elytron>1.12.1.Final</version.org.wildfly.elytron>
         <version.org.wildfly.transaction.client>1.1.11.Final</version.org.wildfly.transaction.client>
         <version.org.jboss.threads>2.3.3.Final</version.org.jboss.threads>
         <version.org.kohsuke.metainf-services>1.7</version.org.kohsuke.metainf-services>


### PR DESCRIPTION
https://issues.redhat.com/browse/WEJBHTTP-42

https://github.com/wildfly-security/wildfly-elytron/compare/1.12.0.Final...1.12.1.Final

        Release Notes - WildFly Elytron - Version 1.12.1.Final
                                                                                                                                    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-1979'>ELY-1979</a>] -         Elytron needs to deal with JEPS 244 in the org.wildfly.security.ssl package
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-1981'>ELY-1981</a>] -         SSL Module missing plugin configuration to assemble multi-version jar
</li>
</ul>
                        
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-1980'>ELY-1980</a>] -         Release WildFly Elytron 1.12.1.Final
</li>
</ul>
                    