### PR TITLE
[WEJBHTTP-45] UT000103 thrown when WildflyClientOutputStream size is …

### DIFF
--- a/common/src/main/java/org/wildfly/httpclient/common/WildflyClientOutputStream.java
+++ b/common/src/main/java/org/wildfly/httpclient/common/WildflyClientOutputStream.java
@@ -169,9 +169,6 @@ class WildflyClientOutputStream extends OutputStream implements ByteOutput {
                     runWriteTask();
                 } else {
                     buffer.put(b, currentOff, currentLen);
-                    if (buffer.remaining() == 0) {
-                        runWriteTask();
-                    }
                     return;
                 }
             }


### PR DESCRIPTION
…exactly 1024 bytes

https://issues.redhat.com/browse/WEJBHTTP-45