### PR TITLE
[WEJBHTTP-48] Close the connection when authentication failed

### DIFF
--- a/common/src/main/java/org/wildfly/httpclient/common/HttpTargetContext.java
+++ b/common/src/main/java/org/wildfly/httpclient/common/HttpTargetContext.java
@@ -196,6 +196,7 @@ public class HttpTargetContext extends AbstractAttachable {
                                                     sendRequestInternal(connection, request, finalAuthenticationConfiguration, httpMarshaller, httpResultHandler, failureHandler, expectedResponse, completedTask, allowNoContent, true, finalSslContext);
                                                 } else {
                                                     failureHandler.handleFailure(HttpClientMessages.MESSAGES.authenticationFailed());
+                                                    connection.done(true);
                                                 }
                                             }, failureHandler::handleFailure, false, finalSslContext);
 


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WEJBHTTP-48

Master PR: https://github.com/wildfly/wildfly-http-client/pull/45