### PR TITLE
Use hostname instead of IP for undertow connection

### DIFF
--- a/common/src/main/java/org/wildfly/httpclient/common/HttpConnectionPool.java
+++ b/common/src/main/java/org/wildfly/httpclient/common/HttpConnectionPool.java
@@ -163,7 +163,7 @@ public class HttpConnectionPool implements Closeable {
                     activeInvocationCount.decrementAndGet();
                     next.errorListener.error(e);
                 }
-            }, new URI(hostPoolAddress.getURI().getScheme(), hostPoolAddress.getURI().getUserInfo(), address.getHostAddress(), hostPoolAddress.getURI().getPort(), "/", null, null), worker, ssl, byteBufferPool, options);
+            }, new URI(hostPoolAddress.getURI().getScheme(), hostPoolAddress.getURI().getUserInfo(), address.getHostName(), hostPoolAddress.getURI().getPort(), "/", null, null), worker, ssl, byteBufferPool, options);
         } catch (URISyntaxException e) {
             next.errorListener.error(e);
         }


### PR DESCRIPTION
Using the IP address causes undertow to create a SNIServerName using this IP instead of the hostname. The SNI server name must be the hostname of the server, otherwise a gateway won't know which virtual host to route the traffic to