### PR TITLE
[WEJBHTTP-51] Http Naming Client does not get root cause of failure of remote bind operation

### DIFF
--- a/naming/src/main/java/org/wildfly/httpclient/naming/HttpRootContext.java
+++ b/naming/src/main/java/org/wildfly/httpclient/naming/HttpRootContext.java
@@ -138,27 +138,28 @@ public class HttpRootContext extends AbstractContext {
 
     @Override
     protected void bindNative(Name name, Object obj) throws NamingException {
-        processInvocation(name, Methods.PUT, obj, "naming/v1/bind/");
+        processInvocation(name, Methods.PUT, obj, "naming/v1/bind/", null);
     }
 
     @Override
     protected void rebindNative(Name name, Object obj) throws NamingException {
-        processInvocation(name, Methods.PATCH, obj, "naming/v1/rebind/");
+        processInvocation(name, Methods.PATCH, obj, "naming/v1/rebind/", null);
     }
 
     @Override
     protected void unbindNative(Name name) throws NamingException {
-        processInvocation(name, Methods.PUT, "naming/v1/unbind/");
+        processInvocation(name, Methods.DELETE, null,"naming/v1/unbind/", null);
     }
 
     @Override
     protected void renameNative(Name oldName, Name newName) throws NamingException {
-        processInvocation(oldName, Methods.PATCH, "naming/v1/rename/", newName);
+        //TODO no result expected
+        processInvocation(oldName, Methods.PATCH, null,"naming/v1/rename/", newName);
     }
 
     @Override
     protected void destroySubcontextNative(Name name) throws NamingException {
-        processInvocation(name, Methods.PUT, "naming/v1/rename/");
+        processInvocation(name, Methods.DELETE, null,"naming/v1/dest-subctx/", null);
     }
 
     @Override
@@ -234,10 +235,6 @@ public class HttpRootContext extends AbstractContext {
     }
 
     private Object processInvocation(Name name, HttpString method, String pathSegment) throws NamingException {
-        return processInvocation(name, method, pathSegment, (Name) null);
-    }
-
-    private Object processInvocation(Name name, HttpString method, String pathSegment, Name newName) throws NamingException {
         ProviderEnvironment environment = httpNamingProvider.getProviderEnvironment();
         final RetryContext context = canRetry(environment) ? new RetryContext() : null;
         return performWithRetry((contextOrNull, name1, param) -> {
@@ -254,10 +251,6 @@ public class HttpRootContext extends AbstractContext {
                 sb.append(pathSegment)
                         .append(URLEncoder.encode(name.toString(), StandardCharsets.UTF_8.name()));
 
-                if (newName != null) {
-                    sb.append("?new=");
-                    sb.append(URLEncoder.encode(newName.toString(), StandardCharsets.UTF_8.name()));
-                }
                 final ClientRequest clientRequest = new ClientRequest()
                         .setPath(sb.toString())
                         .setMethod(method);
@@ -358,7 +351,7 @@ public class HttpRootContext extends AbstractContext {
     }
 
 
-    private void processInvocation(Name name, HttpString method, Object object, String pathSegment) throws NamingException {
+    private void processInvocation(Name name, HttpString method, Object object, String pathSegment, Name newName) throws NamingException {
         ProviderEnvironment environment = httpNamingProvider.getProviderEnvironment();
         final RetryContext context = canRetry(environment) ? new RetryContext() : null;
         performWithRetry((contextOrNull, name1, param) -> {
@@ -372,6 +365,10 @@ public class HttpRootContext extends AbstractContext {
                     sb.append("/");
                 }
                 sb.append(pathSegment).append(URLEncoder.encode(name.toString(), StandardCharsets.UTF_8.name()));
+                if (newName != null) {
+                    sb.append("?new=");
+                    sb.append(URLEncoder.encode(newName.toString(), StandardCharsets.UTF_8.name()));
+                }
                 final ClientRequest clientRequest = new ClientRequest()
                         .setPath(sb.toString())
                         .setMethod(method);

--- a/naming/src/test/java/org/wildfly/httpclient/naming/LocalContext.java
+++ b/naming/src/test/java/org/wildfly/httpclient/naming/LocalContext.java
@@ -1,0 +1,215 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.httpclient.naming;
+
+import javax.naming.Binding;
+import javax.naming.Context;
+import javax.naming.Name;
+import javax.naming.NameClassPair;
+import javax.naming.NameNotFoundException;
+import javax.naming.NameParser;
+import javax.naming.NamingEnumeration;
+import javax.naming.NamingException;
+import javax.naming.OperationNotSupportedException;
+import java.util.Hashtable;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class LocalContext implements Context {
+
+    private final Map<String, Object> bindings = new ConcurrentHashMap<>();
+
+    private final boolean readOnly;
+
+    public LocalContext(boolean readOnly) {
+        bindings.put("test", "test value");
+        bindings.put("comp/UserTransaction", "transaction");
+        this.readOnly = readOnly;
+    }
+
+    @Override
+    public Object lookup(Name name) throws NamingException {
+        return lookup(name.toString());
+    }
+
+    @Override
+    public Object lookup(String name) throws NamingException {
+        Object res = bindings.get(name);
+        if (res == null) {
+            throw new NameNotFoundException();
+        }
+        return res;
+    }
+
+    @Override
+    public void bind(Name name, Object obj) throws NamingException {
+        bind(name.toString(), obj);
+    }
+
+    @Override
+    public void bind(String name, Object obj) throws NamingException {
+        if (readOnly) {
+            throw new OperationNotSupportedException("bind is read-only");
+        }
+        bindings.put(name, obj);
+    }
+
+    @Override
+    public void rebind(Name name, Object obj) throws NamingException {
+        rebind(name.toString(), obj);
+    }
+
+    @Override
+    public void rebind(String name, Object obj) throws NamingException {
+        if (readOnly) {
+            throw new OperationNotSupportedException("rebind is read-only");
+        }
+        bindings.put(name, obj);
+    }
+
+    @Override
+    public void unbind(Name name) throws NamingException {
+        unbind(name.toString());
+    }
+
+    @Override
+    public void unbind(String name) throws NamingException {
+        if (readOnly) {
+            throw new OperationNotSupportedException("unbind is read-only");
+        }
+        bindings.remove(name);
+    }
+
+    @Override
+    public void rename(Name oldName, Name newName) throws NamingException {
+        rename(oldName.toString(), newName.toString());
+    }
+
+    @Override
+    public void rename(String oldName, String newName) throws NamingException {
+        if (readOnly) {
+            throw new OperationNotSupportedException("rename is read-only");
+        }
+        Object obj = bindings.remove(oldName);
+        if (obj == null) {
+            throw new NameNotFoundException();
+        }
+        bindings.put(newName, obj);
+    }
+
+    @Override
+    public NamingEnumeration<NameClassPair> list(Name name) throws NamingException {
+        return list(name.toString());
+    }
+
+    @Override
+    public NamingEnumeration<NameClassPair> list(String name) throws NamingException {
+        return null;
+    }
+
+    @Override
+    public NamingEnumeration<Binding> listBindings(Name name) throws NamingException {
+        return listBindings(name.toString());
+    }
+
+    @Override
+    public NamingEnumeration<Binding> listBindings(String name) throws NamingException {
+        return null;
+    }
+
+    @Override
+    public void destroySubcontext(Name name) throws NamingException {
+        destroySubcontext(name.toString());
+    }
+
+    @Override
+    public void destroySubcontext(String name) throws NamingException {
+        if (readOnly) {
+            throw new OperationNotSupportedException("destroySubcontext is read-only");
+        }
+    }
+
+    @Override
+    public Context createSubcontext(Name name) throws NamingException {
+        return createSubcontext(name.toString());
+    }
+
+    @Override
+    public Context createSubcontext(String name) throws NamingException {
+        if (readOnly) {
+            throw new OperationNotSupportedException("createSubcontext is read-only");
+        }
+        return null;
+    }
+
+    @Override
+    public Object lookupLink(Name name) throws NamingException {
+        return lookupLink(name.toString());
+    }
+
+    @Override
+    public Object lookupLink(String name) throws NamingException {
+        return null;
+    }
+
+    @Override
+    public NameParser getNameParser(Name name) throws NamingException {
+        return null;
+    }
+
+    @Override
+    public NameParser getNameParser(String name) throws NamingException {
+        return null;
+    }
+
+    @Override
+    public Name composeName(Name name, Name prefix) throws NamingException {
+        return null;
+    }
+
+    @Override
+    public String composeName(String name, String prefix) throws NamingException {
+        return null;
+    }
+
+    @Override
+    public Object addToEnvironment(String propName, Object propVal) throws NamingException {
+        return null;
+    }
+
+    @Override
+    public Object removeFromEnvironment(String propName) throws NamingException {
+        return null;
+    }
+
+    @Override
+    public Hashtable<?, ?> getEnvironment() throws NamingException {
+        return null;
+    }
+
+    @Override
+    public void close() throws NamingException {
+
+    }
+
+    @Override
+    public String getNameInNamespace() throws NamingException {
+        return null;
+    }
+}

--- a/naming/src/test/java/org/wildfly/httpclient/naming/ReadOnlyNamingOperationTestCase.java
+++ b/naming/src/test/java/org/wildfly/httpclient/naming/ReadOnlyNamingOperationTestCase.java
@@ -102,4 +102,32 @@ public class ReadOnlyNamingOperationTestCase {
         }
     }
 
+    @Test
+    public void testReadOnlyUnBind() throws Exception {
+        InitialContext ic = createContext();
+        try {
+            ic.unbind("name");
+            Assert.fail("should fail");
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof NamingException);
+            Assert.assertEquals("unbind is read-only", e.getMessage());
+        } finally {
+            ic.close();
+        }
+    }
+
+    @Test
+    public void testReadOnlyDestroySubContext() throws Exception {
+        InitialContext ic = createContext();
+        try {
+            ic.destroySubcontext("subContext");
+            Assert.fail("should fail");
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof NamingException);
+            Assert.assertEquals("destroySubcontext is read-only", e.getMessage());
+        } finally {
+            ic.close();
+        }
+    }
+
 }

--- a/naming/src/test/java/org/wildfly/httpclient/naming/ReadOnlyNamingOperationTestCase.java
+++ b/naming/src/test/java/org/wildfly/httpclient/naming/ReadOnlyNamingOperationTestCase.java
@@ -1,0 +1,105 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.httpclient.naming;
+
+import io.undertow.server.handlers.CookieImpl;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.httpclient.common.HTTPTestServer;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import java.util.Hashtable;
+
+@RunWith(HTTPTestServer.class)
+public class ReadOnlyNamingOperationTestCase {
+
+    @Before
+    public void setup() {
+        HTTPTestServer.registerServicesHandler("/common/v1/affinity", exchange -> exchange.getResponseCookies().put("JSESSIONID", new CookieImpl("JSESSIONID", "foo")));
+        HTTPTestServer.registerServicesHandler("/naming", new HttpRemoteNamingService(new LocalContext(true), f -> false).createHandler());
+    }
+
+    private InitialContext createContext() throws NamingException {
+        Hashtable<String, String> env = new Hashtable<>();
+        env.put(Context.INITIAL_CONTEXT_FACTORY, "org.wildfly.naming.client.WildFlyInitialContextFactory");
+        env.put(Context.PROVIDER_URL, HTTPTestServer.getDefaultServerURL());
+        return new InitialContext(env);
+    }
+
+    @Test
+    public void testReadOnlyBind() throws Exception {
+        InitialContext ic = createContext();
+        try {
+            ic.bind("name", "value");
+            Assert.fail("should fail");
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof NamingException);
+            Assert.assertEquals("bind is read-only", e.getMessage());
+        } finally {
+            ic.close();
+        }
+    }
+
+    @Test
+    public void testReadOnlyReBind() throws Exception {
+        InitialContext ic = createContext();
+        try {
+            ic.rebind("name", "value");
+            Assert.fail("should fail");
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof NamingException);
+            Assert.assertEquals("rebind is read-only", e.getMessage());
+        } finally {
+            ic.close();
+        }
+    }
+
+    @Test
+    public void testReadOnlyReName() throws Exception {
+        InitialContext ic = createContext();
+        try {
+            ic.rename("oldName", "newName");
+            Assert.fail("should fail");
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof NamingException);
+            Assert.assertEquals("rename is read-only", e.getMessage());
+        } finally {
+            ic.close();
+        }
+    }
+
+    @Test
+    public void testReadOnlyCreateSubContext() throws Exception {
+        InitialContext ic = createContext();
+        try {
+            ic.createSubcontext("subContext");
+            Assert.fail("should fail");
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof NamingException);
+            Assert.assertEquals("createSubcontext is read-only", e.getMessage());
+        } finally {
+            ic.close();
+        }
+    }
+
+}

--- a/naming/src/test/java/org/wildfly/httpclient/naming/SimpleNamingOperationTestCase.java
+++ b/naming/src/test/java/org/wildfly/httpclient/naming/SimpleNamingOperationTestCase.java
@@ -131,8 +131,47 @@ public class SimpleNamingOperationTestCase {
     private InitialContext createContext() throws NamingException {
         Hashtable<String, String> env = new Hashtable<>();
         env.put(Context.INITIAL_CONTEXT_FACTORY, "org.wildfly.naming.client.WildFlyInitialContextFactory");
-        env.put(Context.PROVIDER_URL, "http://127.0.0.1:10," + HTTPTestServer.getDefaultServerURL());
+        env.put(Context.PROVIDER_URL, HTTPTestServer.getDefaultServerURL());
         return new InitialContext(env);
+    }
+
+    @Test
+    public void testSimpleUnbind() throws Exception {
+        InitialContext ic = createContext();
+        Assert.assertEquals("test value", ic.lookup("test").toString());
+        ic.unbind("test");
+        try {
+            ic.lookup("test");
+            Assert.fail("test is not available anymore");
+        } catch (NameNotFoundException e) {
+        }
+    }
+
+    @Test
+    public void testSimpleSubContext() throws Exception {
+        InitialContext ic = createContext();
+        ic.createSubcontext("subContext");
+        Context subContext = (Context)ic.lookup("subContext");
+        Assert.assertNotNull(subContext);
+        ic.destroySubcontext("subContext");
+        try {
+            ic.lookup("subContext");
+            Assert.fail("subContext is not available anymore");
+        } catch (NameNotFoundException e) {
+        }
+    }
+
+    @Test
+    public void testSimpleRename() throws Exception {
+        InitialContext ic = createContext();
+        Assert.assertEquals("test value", ic.lookup("test").toString());
+        ic.rename("test", "testB");
+        try {
+            ic.lookup("test");
+            Assert.fail("test is not available anymore");
+        } catch (NameNotFoundException e) {
+        }
+        Assert.assertEquals("test value", ic.lookup("testB").toString());
     }
 
 }


### PR DESCRIPTION
Issue: https://github.com/wildfly/wildfly-http-client/pull/48

This is a back port of https://github.com/wildfly/wildfly-http-client/pull/48 to `1.0` branch.