### PR TITLE
[WEJBHTTP-50] At WildFlyClientOutputStream listener, when write retur…

### DIFF
--- a/common/src/main/java/org/wildfly/httpclient/common/WildflyClientOutputStream.java
+++ b/common/src/main/java/org/wildfly/httpclient/common/WildflyClientOutputStream.java
@@ -90,6 +90,7 @@ class WildflyClientOutputStream extends OutputStream implements ByteOutput {
                                 res = streamSinkChannel.write(pooledBuffer.getBuffer());
                             }
                             if (res == 0) {
+                                pooledBuffer.getBuffer().compact(); // WEJBHTTP-50 compact the buffer to be able to flip it when listener is invoked again
                                 return;
                             }
                         }


### PR DESCRIPTION
…ns 0, compact the buffer before returning, so it can be safely flipped when listener is invoked again

Jira: https://issues.redhat.com/browse/WEJBHTTP-50
master PR: #52 