### PR TITLE
[WEJBHTTP-36] SimpleInvocationTestCase.testSimpleInvocationWithURLNeedingEncoding is broken

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -85,6 +85,17 @@
             <artifactId>jboss-logmanager</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.wildfly.security.elytron-web</groupId>
+            <artifactId>undertow-common-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.security.elytron-web</groupId>
+            <artifactId>undertow-server</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 

--- a/ejb/pom.xml
+++ b/ejb/pom.xml
@@ -121,6 +121,16 @@
             <artifactId>jboss-modules</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.wildfly.security.elytron-web</groupId>
+            <artifactId>undertow-common-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.security.elytron-web</groupId>
+            <artifactId>undertow-server</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 

--- a/ejb/src/test/java/org/wildfly/httpclient/ejb/SimpleInvocationTestCase.java
+++ b/ejb/src/test/java/org/wildfly/httpclient/ejb/SimpleInvocationTestCase.java
@@ -98,7 +98,7 @@ public class SimpleInvocationTestCase {
      * @throws Exception
      * @see <a href="https://issues.jboss.org/browse/WFLY-9788">WFLY-9788</a> for more details
      */
-    @Test @Ignore // FIXME WEJBHTTP-36
+    @Test
     public void testSimpleInvocationWithURLNeedingEncoding() throws Exception {
         EJBTestServer.setHandler((invocation, affinity, out, methodLocator, handle, attachments) -> {
             // check the invoked method and make sure it maps correctly to the view interface's method

--- a/naming/pom.xml
+++ b/naming/pom.xml
@@ -100,6 +100,16 @@
             <artifactId>jboss-logmanager</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.wildfly.security.elytron-web</groupId>
+            <artifactId>undertow-common-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.security.elytron-web</groupId>
+            <artifactId>undertow-server</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
         <!-- Versions -->
-        <version.io.undertow>2.1.1.Final</version.io.undertow>
+        <version.io.undertow>2.2.4.Final</version.io.undertow>
         <version.org.jboss.logging>3.4.1.Final</version.org.jboss.logging>
         <version.org.jboss.logging-tools>2.2.1.Final</version.org.jboss.logging-tools>
         <version.org.junit>4.13.1</version.org.junit>
@@ -65,7 +65,7 @@
         <version.org.wildfly.client-config>1.0.1.Final</version.org.wildfly.client-config>
         <version.org.wildfly.common>1.5.4.Final</version.org.wildfly.common>
         <version.org.wildfly.naming.client>1.0.12.Final</version.org.wildfly.naming.client>
-        <version.org.wildfly.elytron>1.12.1.Final</version.org.wildfly.elytron>
+        <version.org.wildfly.elytron>1.15.0.Final</version.org.wildfly.elytron>
         <version.org.wildfly.transaction.client>1.1.11.Final</version.org.wildfly.transaction.client>
         <version.org.jboss.threads>2.3.3.Final</version.org.jboss.threads>
         <version.org.kohsuke.metainf-services>1.7</version.org.kohsuke.metainf-services>

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,7 @@
         <version.org.wildfly.common>1.5.4.Final</version.org.wildfly.common>
         <version.org.wildfly.naming.client>1.0.12.Final</version.org.wildfly.naming.client>
         <version.org.wildfly.elytron>1.15.0.Final</version.org.wildfly.elytron>
+        <version.org.wildfly.elytron.web>1.9.0.Final</version.org.wildfly.elytron.web>
         <version.org.wildfly.transaction.client>1.1.11.Final</version.org.wildfly.transaction.client>
         <version.org.jboss.threads>2.3.3.Final</version.org.jboss.threads>
         <version.org.kohsuke.metainf-services>1.7</version.org.kohsuke.metainf-services>
@@ -230,7 +231,18 @@
                 <version>${version.org.jboss.modules}</version>
                 <scope>test</scope>
             </dependency>
-
+            <dependency>
+                <groupId>org.wildfly.security.elytron-web</groupId>
+                <artifactId>undertow-common-test</artifactId>
+                <version>${version.org.wildfly.elytron.web}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.wildfly.security.elytron-web</groupId>
+                <artifactId>undertow-server</artifactId>
+                <version>${version.org.wildfly.elytron.web}</version>
+                <scope>test</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/transaction/pom.xml
+++ b/transaction/pom.xml
@@ -107,6 +107,16 @@
             <artifactId>jboss-modules</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.wildfly.security.elytron-web</groupId>
+            <artifactId>undertow-common-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.security.elytron-web</groupId>
+            <artifactId>undertow-server</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WEJBHTTP-36

The cause of the test failure is an issue in Undertow's implementation of `DigestAuthenticationMechanism`, which failed to match the request uri with the one in request header. This PR tries to use the implementation from Elytron, which is also used in WildFly server currently. 

This PR also tries to upgrade undertow to 2.2.4.Final and elytron to 1.15.0.Final to sync with wildfly.

