### PR TITLE
[WEJBHTTP-56] set SSLContext according to target context uri when creating HttpSubordinateTransactionHandle

### DIFF
--- a/transaction/src/main/java/org/wildfly/httpclient/transaction/HttpRemoteTransactionPeer.java
+++ b/transaction/src/main/java/org/wildfly/httpclient/transaction/HttpRemoteTransactionPeer.java
@@ -66,7 +66,11 @@ public class HttpRemoteTransactionPeer implements RemoteTransactionPeer {
 
     @Override
     public SubordinateTransactionControl lookupXid(Xid xid) throws XAException {
-        return new HttpSubordinateTransactionHandle(xid, targetContext, sslContext, authenticationConfiguration);
+        try {
+            return new HttpSubordinateTransactionHandle(xid, targetContext, getSslContext(targetContext.getUri()), authenticationConfiguration);
+        } catch (GeneralSecurityException e) {
+            throw new XAException(e.getMessage());
+        }
     }
 
     @Override


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WEJBHTTP-56

This is the new approach than #56 to fix the https problem in 2nd --> 3rd ejb calls, this approach does not need changes in wildfly-transaction-client anymore.
