### PR TITLE
Ignore SimpleInvocationTestCase#testSimpleSSLInvocationViaURLAffinity

### DIFF
--- a/ejb/src/test/java/org/wildfly/httpclient/ejb/SimpleInvocationTestCase.java
+++ b/ejb/src/test/java/org/wildfly/httpclient/ejb/SimpleInvocationTestCase.java
@@ -165,6 +165,7 @@ public class SimpleInvocationTestCase {
     }
 
     @Test
+    @Ignore("https://issues.redhat.com/browse/WEJBHTTP-55")
     public void testSimpleSSLInvocationViaURLAffinity() throws Exception {
         for (int i = 0; i < RETRIES; ++i) {
             clearSessionId();


### PR DESCRIPTION
Already logged in https://issues.redhat.com/browse/WEJBHTTP-55. I am setting up continuous builds on top of this branch for CP stream and this is blocking the continuous test build. Let me know if it should also go to the master branch.