### PR TITLE
[WEJBHTTP-69] HttpRemoteNamingService#list and listBindings have to r…

### DIFF
--- a/naming/src/main/java/org/wildfly/httpclient/naming/HttpRemoteNamingService.java
+++ b/naming/src/main/java/org/wildfly/httpclient/naming/HttpRemoteNamingService.java
@@ -23,9 +23,13 @@ import java.io.InputStream;
 import java.io.InvalidClassException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.util.Collections;
 import java.util.Deque;
 import java.util.function.Function;
+import javax.naming.Binding;
 import javax.naming.Context;
+import javax.naming.NameClassPair;
+import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;
 
 import org.jboss.marshalling.ContextClassResolver;
@@ -157,7 +161,8 @@ public class HttpRemoteNamingService {
     private class ListBindingsHandler extends NameHandler {
         @Override
         protected Object doOperation(HttpServerExchange exchange, String name) throws NamingException {
-            return localContext.listBindings(name);
+            final NamingEnumeration<Binding> namingEnumeration = localContext.listBindings(name);
+            return Collections.list(namingEnumeration);
         }
     }
 
@@ -191,7 +196,8 @@ public class HttpRemoteNamingService {
     private class ListHandler extends NameHandler {
         @Override
         protected Object doOperation(HttpServerExchange exchange, String name) throws NamingException {
-            return localContext.list(name);
+            final NamingEnumeration<NameClassPair> namingEnumeration = localContext.list(name);
+            return Collections.list(namingEnumeration);
         }
     }
 

--- a/naming/src/test/java/org/wildfly/httpclient/naming/LocalContext.java
+++ b/naming/src/test/java/org/wildfly/httpclient/naming/LocalContext.java
@@ -30,6 +30,7 @@ import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;
 import javax.naming.OperationNotSupportedException;
 import java.util.Hashtable;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -128,7 +129,28 @@ public class LocalContext implements Context {
 
     @Override
     public NamingEnumeration<NameClassPair> list(String name) throws NamingException {
-        return null;
+        final Iterator<String> iterator = bindings.keySet().iterator();
+        return new NamingEnumeration<NameClassPair>() {
+            public NameClassPair next() {
+                return nextElement();
+            }
+
+            public boolean hasMore() {
+                return hasMoreElements();
+            }
+
+            public void close() {
+            }
+
+            public boolean hasMoreElements() {
+                return iterator.hasNext();
+            }
+
+            public NameClassPair nextElement() {
+                final String name = iterator.next();
+                return new NameClassPair(name, (String)null);
+            }
+        };
     }
 
     @Override
@@ -138,7 +160,28 @@ public class LocalContext implements Context {
 
     @Override
     public NamingEnumeration<Binding> listBindings(String name) throws NamingException {
-        return null;
+        final Iterator<String> iterator = bindings.keySet().iterator();
+        return new NamingEnumeration<Binding>() {
+            public Binding next() {
+                return nextElement();
+            }
+
+            public boolean hasMore() {
+                return hasMoreElements();
+            }
+
+            public void close() {
+            }
+
+            public boolean hasMoreElements() {
+                return iterator.hasNext();
+            }
+
+            public Binding nextElement() {
+                final String name = iterator.next();
+                return new Binding(name, bindings.get(name));
+            }
+        };
     }
 
     @Override

--- a/naming/src/test/java/org/wildfly/httpclient/naming/SimpleNamingOperationTestCase.java
+++ b/naming/src/test/java/org/wildfly/httpclient/naming/SimpleNamingOperationTestCase.java
@@ -20,9 +20,12 @@ package org.wildfly.httpclient.naming;
 
 import java.util.Hashtable;
 import java.util.function.Function;
+import javax.naming.Binding;
 import javax.naming.Context;
 import javax.naming.InitialContext;
+import javax.naming.NameClassPair;
 import javax.naming.NameNotFoundException;
+import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;
 
 import org.junit.Assert;
@@ -174,4 +177,17 @@ public class SimpleNamingOperationTestCase {
         Assert.assertEquals("test value", ic.lookup("testB").toString());
     }
 
+    @Test   // WEJBHTTP-69
+    public void testListCanBeSerialized() throws Exception {
+        InitialContext ic = createContext();
+        NamingEnumeration<NameClassPair> list = ic.list("test");
+        Assert.assertNotNull(list);
+    }
+
+    @Test   // WEJBHTTP-69
+    public void testListBindingsCanBeSerialized() throws Exception {
+        InitialContext ic = createContext();
+        NamingEnumeration<Binding> list = ic.listBindings("test");
+        Assert.assertNotNull(list);
+    }
 }


### PR DESCRIPTION
…eturn List instead of NamingEnumeration due to serialization issues

https://issues.redhat.com/browse/WEJBHTTP-69