### PR TITLE
[WEJBHTTP-70][WEJBHTTP-78] At WildFlyClientInputStream.runReadTask() invoke resumeWrites and upgrade Undertow to 2.2.17.Final

### DIFF
--- a/common/src/main/java/org/wildfly/httpclient/common/WildflyClientInputStream.java
+++ b/common/src/main/java/org/wildfly/httpclient/common/WildflyClientInputStream.java
@@ -163,7 +163,7 @@ class WildflyClientInputStream extends InputStream {
     private void runReadTask() {
         Assert.assertTrue(pooledByteBuffer == null);
         channel.getReadSetter().set(channelListener);
-        channel.wakeupReads(); //should just be resume, see UNDERTOW-1192
+        channel.resumeReads();
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
         <!-- Versions -->
-        <version.io.undertow>2.2.5.Final</version.io.undertow>
+        <version.io.undertow>2.2.17.Final</version.io.undertow>
         <version.org.jboss.logging>3.4.1.Final</version.org.jboss.logging>
         <version.org.jboss.logging-tools>2.2.1.Final</version.org.jboss.logging-tools>
         <version.org.junit>4.13.1</version.org.junit>


### PR DESCRIPTION
Jiras: https://issues.redhat.com/browse/WEJBHTTP-78
         https://issues.redhat.com/browse/WEJBHTTP-70