### PR TITLE
[WEJBHTTP-80] Digest authentication creates URI with port -1 when using standard ports

### DIFF
--- a/common/src/main/java/org/wildfly/httpclient/common/PoolAuthenticationContext.java
+++ b/common/src/main/java/org/wildfly/httpclient/common/PoolAuthenticationContext.java
@@ -119,6 +119,50 @@ class PoolAuthenticationContext {
         return false;
     }
 
+    static String createTargetUri(URI uri, ClientRequest request) {
+        String path;
+        String query;
+        int pos = request.getPath().indexOf("?");
+        if (pos > 0) {
+            path = request.getPath().substring(0, pos);
+            query = request.getPath().substring(pos + 1);
+        } else {
+            path = request.getPath();
+            query = null;
+        }
+        String scheme = uri.getScheme();
+        String host = uri.getHost();
+        int port = uri.getPort();
+        StringBuilder uriBuilder = new StringBuilder();
+        if (scheme != null) {
+            uriBuilder.append(scheme);
+            uriBuilder.append(':');
+        }
+        if (host != null) {
+            uriBuilder.append("//");
+            boolean needBrackets = ((host.indexOf(':') >= 0)
+                    && !host.startsWith("[")
+                    && !host.endsWith("]"));
+            if (needBrackets) {
+                uriBuilder.append('[');
+            }
+            uriBuilder.append(host);
+            if (needBrackets) {
+                uriBuilder.append(']');
+            }
+        }
+        if (port != -1 && !(("http".equals(scheme) && port == 80) || ("https".equals(scheme) && port == 443))) {
+            uriBuilder.append(':');
+            uriBuilder.append(port);
+        }
+        uriBuilder.append(path);
+        if (query != null && !query.isEmpty()) {
+            uriBuilder.append("?");
+            uriBuilder.append(query);
+        }
+        return uriBuilder.toString();
+    }
+
     boolean prepareRequest(URI uri, ClientRequest request, AuthenticationConfiguration authenticationConfiguration) {
         if (current == Type.NONE) {
             return false;
@@ -157,48 +201,7 @@ class PoolAuthenticationContext {
                 return false;
             }
             String cnonce = cnonceGenerator.createSessionId();
-            String path;
-            String query;
-            int pos = request.getPath().indexOf("?");
-            if (pos > 0) {
-                path = request.getPath().substring(0, pos);
-                query = request.getPath().substring(pos + 1);
-            } else {
-                path = request.getPath();
-                query = null;
-            }
-            String scheme = uri.getScheme();
-            String host = uri.getHost();
-            int port = uri.getPort();
-            StringBuilder uriBuilder = new StringBuilder();
-            if (scheme != null) {
-                uriBuilder.append(scheme);
-                uriBuilder.append(':');
-            }
-            if (host != null) {
-                uriBuilder.append("//");
-                boolean needBrackets = ((host.indexOf(':') >= 0)
-                        && ! host.startsWith("[")
-                        && ! host.endsWith("]"));
-                if (needBrackets) {
-                    uriBuilder.append('[');
-                }
-                uriBuilder.append(host);
-                if (needBrackets) {
-                    uriBuilder.append(']');
-                }
-            }
-            if (! (("http".equals(scheme) && port == 80) || ("https".equals(scheme) && port == 443))) {
-                uriBuilder.append(':');
-                uriBuilder.append(port);
-            }
-            uriBuilder.append(path);
-            if (query != null && ! query.isEmpty()) {
-                uriBuilder.append("?");
-                uriBuilder.append(query);
-            }
-            String digestUri = uriBuilder.toString();
-
+            String digestUri = createTargetUri(uri, request);
             request.putAttachment(DIGEST, current);
             StringBuilder sb = new StringBuilder("Digest username=\"");
             sb.append(principal.getName());

--- a/common/src/test/java/org/wildfly/httpclient/common/PoolAuthenticationContextTestCase.java
+++ b/common/src/test/java/org/wildfly/httpclient/common/PoolAuthenticationContextTestCase.java
@@ -1,0 +1,76 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2022 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.httpclient.common;
+
+import io.undertow.client.ClientRequest;
+import java.net.URI;
+import java.net.URISyntaxException;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ *
+ * @author rmartinc
+ */
+public class PoolAuthenticationContextTestCase {
+
+    @Test
+    public void testCreateTargetUriWithParams() throws URISyntaxException {
+        ClientRequest req = new ClientRequest();
+        req.setPath("/te%2Bst/test.html?param1=value1&param2=val%20ue2");
+
+        Assert.assertEquals("http://localhost:8080/te%2Bst/test.html?param1=value1&param2=val%20ue2",
+                PoolAuthenticationContext.createTargetUri(new URI("http://localhost:8080"), req));
+        Assert.assertEquals("http://localhost/te%2Bst/test.html?param1=value1&param2=val%20ue2",
+                PoolAuthenticationContext.createTargetUri(new URI("http://localhost"), req));
+        Assert.assertEquals("http://localhost/te%2Bst/test.html?param1=value1&param2=val%20ue2",
+                PoolAuthenticationContext.createTargetUri(new URI("http://localhost:80"), req));
+        Assert.assertEquals("https://localhost/te%2Bst/test.html?param1=value1&param2=val%20ue2",
+                PoolAuthenticationContext.createTargetUri(new URI("https://localhost"), req));
+        Assert.assertEquals("https://localhost/te%2Bst/test.html?param1=value1&param2=val%20ue2",
+                PoolAuthenticationContext.createTargetUri(new URI("https://localhost:443"), req));
+    }
+
+    @Test
+    public void testCreateTargetUriWithoutParams() throws URISyntaxException {
+        ClientRequest req = new ClientRequest();
+        req.setPath("/te%2Bst/test.html");
+
+        Assert.assertEquals("http://localhost:8080/te%2Bst/test.html",
+                PoolAuthenticationContext.createTargetUri(new URI("http://localhost:8080"), req));
+        Assert.assertEquals("http://localhost/te%2Bst/test.html",
+                PoolAuthenticationContext.createTargetUri(new URI("http://localhost"), req));
+        Assert.assertEquals("http://localhost/te%2Bst/test.html",
+                PoolAuthenticationContext.createTargetUri(new URI("http://localhost:80"), req));
+        Assert.assertEquals("https://localhost/te%2Bst/test.html",
+                PoolAuthenticationContext.createTargetUri(new URI("https://localhost"), req));
+        Assert.assertEquals("https://localhost/te%2Bst/test.html",
+                PoolAuthenticationContext.createTargetUri(new URI("https://localhost:443"), req));
+    }
+
+    @Test
+    public void testCreateTargetUriIPv6() throws URISyntaxException {
+        ClientRequest req = new ClientRequest();
+        req.setPath("/te%2Bst/test.html");
+
+        Assert.assertEquals("http://[::1]/te%2Bst/test.html",
+                PoolAuthenticationContext.createTargetUri(new URI("http", "::1", null, null), req));
+    }
+
+}


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WEJBHTTP-80

The only line really changed is [this one](https://github.com/rmartinc/wildfly-http-client/blob/ff9442cc6790e31681c42ab5aaef9ad8de49e311/common/src/main/java/org/wildfly/httpclient/common/PoolAuthenticationContext.java#L154) which avoids adding port -1. But moving the relevant code to a method to create a simple test that checks different URLs.

@fl4via Check this when you have time. It's a simple PR but it fixes an important issue. If you want this in another branch or repo (gitlab), just let me know. 