### PR TITLE
WEJBHTTP-97 Upgrade jakarta.transaction-api from 2.0.0 to 2.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <version.org.jboss.ejb-client>5.0.0.Final</version.org.jboss.ejb-client>
         <version.org.wildfly.discovery>1.2.1.Final</version.org.wildfly.discovery>
         <version.jakarta.ejb.jakarta-ejb-api>4.0.1</version.jakarta.ejb.jakarta-ejb-api>
-        <version.jakarta.transaction.jakarta-transaction-api>2.0.0</version.jakarta.transaction.jakarta-transaction-api>
+        <version.jakarta.transaction.jakarta-transaction-api>2.0.1</version.jakarta.transaction.jakarta-transaction-api>
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
         <version.org.jboss.marshalling>2.1.1.Final</version.org.jboss.marshalling>
         <version.org.jboss.modules>1.10.0.Final</version.org.jboss.modules>


### PR DESCRIPTION
https://issues.redhat.com/browse/WEJBHTTP-97