### PR TITLE
[WEJBHTTP-104] HttpNamingEjbObjectResolverHelper not being used in HttpRootContext

### DIFF
--- a/naming/src/main/java/org/wildfly/httpclient/naming/HttpRootContext.java
+++ b/naming/src/main/java/org/wildfly/httpclient/naming/HttpRootContext.java
@@ -184,14 +184,14 @@ public class HttpRootContext extends AbstractContext {
 
     private static Marshaller createMarshaller(URI uri, HttpMarshallerFactory httpMarshallerFactory) throws IOException {
         if (helper != null) {
-            httpMarshallerFactory.createMarshaller(helper.getObjectResolver(uri));
+            return httpMarshallerFactory.createMarshaller(helper.getObjectResolver(uri));
         }
         return httpMarshallerFactory.createMarshaller();
     }
 
     private static Unmarshaller createUnmarshaller(URI uri, HttpMarshallerFactory httpMarshallerFactory) throws IOException {
         if (helper != null) {
-            httpMarshallerFactory.createUnmarshaller(helper.getObjectResolver(uri));
+            return httpMarshallerFactory.createUnmarshaller(helper.getObjectResolver(uri));
         }
         return httpMarshallerFactory.createUnmarshaller();
     }

--- a/naming/src/test/java/org/wildfly/httpclient/naming/LocalContext.java
+++ b/naming/src/test/java/org/wildfly/httpclient/naming/LocalContext.java
@@ -43,6 +43,7 @@ public class LocalContext implements Context {
     public LocalContext(boolean readOnly) {
         bindings.put("test", "test value");
         bindings.put("comp/UserTransaction", "transaction");
+        bindings.put("test-resolver-helper", TestHttpNamingEjbObjectResolverHelper.create("test"));
         this.readOnly = readOnly;
     }
 

--- a/naming/src/test/java/org/wildfly/httpclient/naming/SimpleNamingOperationTestCase.java
+++ b/naming/src/test/java/org/wildfly/httpclient/naming/SimpleNamingOperationTestCase.java
@@ -190,4 +190,15 @@ public class SimpleNamingOperationTestCase {
         NamingEnumeration<Binding> list = ic.listBindings("test");
         Assert.assertNotNull(list);
     }
+
+    @Test
+    public void testHttpNamingEjbObjectResolverHelper() throws NamingException {
+        InitialContext ic = createContext();
+        Assert.assertEquals(TestHttpNamingEjbObjectResolverHelper.create("readResolve->" + HTTPTestServer.getDefaultServerURL()),
+                ic.lookup("test-resolver-helper"));
+
+        ic.rebind("test-resolver-helper", TestHttpNamingEjbObjectResolverHelper.create("test"));
+        Assert.assertEquals(TestHttpNamingEjbObjectResolverHelper.create("writeReplace->" + HTTPTestServer.getDefaultServerURL()),
+                ic.lookup("test-resolver-helper"));
+    }
 }

--- a/naming/src/test/java/org/wildfly/httpclient/naming/TestHttpNamingEjbObjectResolverHelper.java
+++ b/naming/src/test/java/org/wildfly/httpclient/naming/TestHttpNamingEjbObjectResolverHelper.java
@@ -1,0 +1,101 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2022 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.httpclient.naming;
+
+import java.io.Serializable;
+import java.net.URI;
+import java.util.Objects;
+import org.jboss.marshalling.ObjectResolver;
+
+/**
+ * <p>A test HttpNamingEjbObjectResolverHelper that transform a TestObject
+ * with value <em>test</em> to <em>readResolve/writeReplace->URI</em></p>.
+ *
+ * @author rmartinc
+ */
+public class TestHttpNamingEjbObjectResolverHelper implements HttpNamingEjbObjectResolverHelper {
+
+    /**
+     * Serializable test class.
+     */
+    public static class TestObject implements Serializable {
+        private String value;
+
+        private TestObject(String value) {
+            this.value = value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        @Override
+        public int hashCode() {
+            return 217 + Objects.hashCode(this.value);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj instanceof TestObject) {
+                return Objects.equals(this.value, ((TestObject) obj).value);
+            }
+            return false;
+        }
+
+        @Override
+        public String toString() {
+            return value;
+        }
+    }
+
+    /**
+     * Creates a TestObject with the passed value.
+     *
+     * @param value The test value.
+     * @return The created TestObject.
+     */
+    public static TestObject create(String value) {
+        return new TestObject(value);
+    }
+
+    @Override
+    public ObjectResolver getObjectResolver(URI uri) {
+        return new ObjectResolver() {
+            @Override
+            public Object readResolve(Object replacement) {
+                if (create("test").equals(replacement)) {
+                    return create("readResolve->" + uri);
+                }
+                return replacement;
+            }
+
+            @Override
+            public Object writeReplace(Object original) {
+                if (create("test").equals(original)) {
+                    return create("writeReplace->" + uri);
+                }
+                return original;
+            }
+        };
+    }
+
+}

--- a/naming/src/test/resources/META-INF/services/org.wildfly.httpclient.naming.HttpNamingEjbObjectResolverHelper
+++ b/naming/src/test/resources/META-INF/services/org.wildfly.httpclient.naming.HttpNamingEjbObjectResolverHelper
@@ -1,0 +1,1 @@
+org.wildfly.httpclient.naming.TestHttpNamingEjbObjectResolverHelper


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WEJBHTTP-104

Just returning the created (un)marshaller when the helper is not null. Little test added to ensure the `ObjectResolver`  is used inside the context.