### PR TITLE
[WEJBHTTP-74] The http ejb client should use the servers hostname for the TLS SNI extension during handshake

### DIFF
--- a/common/src/test/java/org/wildfly/httpclient/common/ClientSNITestCase.java
+++ b/common/src/test/java/org/wildfly/httpclient/common/ClientSNITestCase.java
@@ -1,0 +1,113 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2022 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.httpclient.common;
+
+import io.undertow.client.ClientRequest;
+import io.undertow.server.SSLSessionInfo;
+import io.undertow.util.Methods;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import javax.net.ssl.ExtendedSSLSession;
+import javax.net.ssl.SNIHostName;
+import javax.net.ssl.SNIServerName;
+import javax.net.ssl.SSLContext;
+import org.assertj.core.api.Assertions;
+import org.junit.Assume;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.security.auth.client.AuthenticationConfiguration;
+
+/**
+ * <p>Test that checks the SNI server is set to the real hostname used in the URI</p>
+ *
+ * @author rmartinc
+ */
+@RunWith(HTTPTestServer.class)
+public class ClientSNITestCase {
+
+    @Test
+    public void testSNIWithHostname() throws Throwable {
+        InetAddress address = InetAddress.getByName(HTTPTestServer.getHostAddress());
+        Assume.assumeTrue("Assuming the test if no resolution for the address", !address.getHostName().equals(address.getHostAddress()));
+
+        SSLContext sslContext = HTTPTestServer.createClientSSLContext();
+        final String path = "/host";
+        final List<SNIServerName> result = new ArrayList<>(1);
+        HTTPTestServer.registerPathHandler(path, exchange -> {
+            if (path.equals(exchange.getRequestURI())) {
+                SSLSessionInfo ssl = exchange.getConnection().getSslSessionInfo();
+                if (ssl != null && ssl.getSSLSession() instanceof ExtendedSSLSession) {
+                    result.addAll(((ExtendedSSLSession) ssl.getSSLSession()).getRequestedServerNames());
+                }
+            }
+        });
+
+        ClientRequest request = new ClientRequest().setMethod(Methods.GET).setPath(path);
+        URI uri = new URI("https://" + address.getHostName() + ":" + HTTPTestServer.getSSLHostPort() + request.getPath());
+        doClientRequest(request, uri, sslContext);
+
+        Assertions.assertThat(result)
+                .as("Check sni names contains " + address.getHostName())
+                .containsExactly(new SNIHostName(address.getHostName()));
+    }
+
+    @Test
+    public void testNoSNIWithIP() throws Throwable {
+        InetAddress address = InetAddress.getByName(HTTPTestServer.getHostAddress());
+        Assume.assumeTrue("Assuming the test if no resolution for the address", !address.getHostName().equals(address.getHostAddress()));
+        String hostname = address instanceof Inet6Address? "[" + address.getHostAddress() + "]" : address.getHostAddress();
+
+        SSLContext sslContext = HTTPTestServer.createClientSSLContext();
+        final String path = "/host";
+        final List<SNIServerName> result = new ArrayList<>(1);
+        HTTPTestServer.registerPathHandler(path, exchange -> {
+            if (path.equals(exchange.getRequestURI())) {
+                SSLSessionInfo ssl = exchange.getConnection().getSslSessionInfo();
+                if (ssl != null && ssl.getSSLSession() instanceof ExtendedSSLSession) {
+                    result.addAll(((ExtendedSSLSession) ssl.getSSLSession()).getRequestedServerNames());
+                }
+            }
+        });
+
+        ClientRequest request = new ClientRequest().setMethod(Methods.GET).setPath(path);
+        URI uri = new URI("https://" + hostname + ":" + HTTPTestServer.getSSLHostPort() + request.getPath());
+        doClientRequest(request, uri, sslContext);
+
+        Assertions.assertThat(result)
+                .as("Check no SNI names with IP")
+                .isEmpty();
+    }
+
+    private void doClientRequest(ClientRequest request, URI uri, SSLContext sslContext) throws Throwable {
+        ClientAuthUtils.setupBasicAuth(request, uri);
+
+        final CompletableFuture<Void> future = new CompletableFuture<>();
+        HttpTargetContext context = WildflyHttpContext.getCurrent().getTargetContext(uri);
+        context.sendRequest(request, sslContext, AuthenticationConfiguration.empty(), null,
+                (result, response, doneCallback) -> future.complete(null),
+                throwable -> future.completeExceptionally(throwable),
+                null, null, true);
+        future.get(10, TimeUnit.SECONDS);
+    }
+}

--- a/common/src/test/java/org/wildfly/httpclient/common/HTTPTestServer.java
+++ b/common/src/test/java/org/wildfly/httpclient/common/HTTPTestServer.java
@@ -281,6 +281,10 @@ public class HTTPTestServer extends BlockJUnit4ClassRunner {
         return createSSLContext(loadKeyStore(SERVER_KEY_STORE), loadKeyStore(SERVER_TRUST_STORE));
     }
 
+    public static SSLContext createClientSSLContext() {
+        return createSSLContext(loadKeyStore(CLIENT_KEY_STORE), loadKeyStore(CLIENT_TRUST_STORE));
+    }
+
     private static SSLContext createSSLContext(final KeyStore keyStore, final KeyStore trustStore) {
         KeyManager[] keyManagers;
         try {

--- a/common/src/test/resources/wildfly-config.xml
+++ b/common/src/test/resources/wildfly-config.xml
@@ -36,9 +36,7 @@
     </discovery>
     <authentication-client xmlns="urn:elytron:1.0">
         <authentication-rules>
-            <rule use-configuration="administrator">
-                <match-host name="localhost" />
-            </rule>
+            <rule use-configuration="administrator"/>
         </authentication-rules>
         <authentication-configurations>
             <configuration name="administrator">

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.source>11</maven.compiler.source>
         <!-- Versions -->
-        <version.io.undertow>2.2.17.Final</version.io.undertow>
+        <version.io.undertow>2.2.22.Final</version.io.undertow>
         <version.org.jboss.logging>3.4.1.Final</version.org.jboss.logging>
         <version.org.jboss.logging-tools>2.2.1.Final</version.org.jboss.logging-tools>
         <version.org.junit>4.13.1</version.org.junit>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WEJBHTTP-74

Using the new option in UNDERTOW-2198 the client now assigns the `SSL_SNI_HOSTNAME` to force the SNI even the IP is used. Upgrading to undertow 2.2.22. The option is just added if using https and if the IP is not used in the hostname. Tests added.

PR for master.
PR for 1.1: https://github.com/wildfly/wildfly-http-client/pull/98