### PR TITLE
Fix system property to enable interop testing in testsuite.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -360,7 +360,7 @@
                             <goals><goal>test</goal></goals>
                             <configuration>
                                 <systemPropertyVariables>
-                                    <org.wildfly.ee.interoperable>true</org.wildfly.ee.interoperable>
+                                    <org.wildfly.ee.namespace.interop>true</org.wildfly.ee.namespace.interop>
                                 </systemPropertyVariables>
                                 <reportsDirectory>${project.build.directory}/surefire-ee-interoperable-reports</reportsDirectory>
                             </configuration>


### PR DESCRIPTION
The name of the system property used to enable interoperability mode in the testsuite pom (org.wildfly.ee.interoperable) did not match the system property in the code (org.wildfly.ee.namespace.interop); consequently, no interop testing was being carried out.