### PR TITLE
[WEJBHTTP-112] Close marshalling output stream used in HttpRootContext safely.

### DIFF
--- a/naming/src/main/java/org/wildfly/httpclient/naming/HttpRootContext.java
+++ b/naming/src/main/java/org/wildfly/httpclient/naming/HttpRootContext.java
@@ -439,7 +439,7 @@ public class HttpRootContext extends AbstractContext {
                 marshaller.writeObject(object);
                 marshaller.finish();
             }
-            output.close();
+            IoUtils.safeClose(output);
         }, (input, response, closeable) -> {
             try {
                 result.complete(null);


### PR DESCRIPTION
This PR does the following:
* adds an IoUtils.safeClose() wrapper to the closing of an output stream used for marshalling in HttpRootContext.performOperation method

For more details, see: https://issues.redhat.com/browse/WEJBHTTP-112