### PR TITLE
[WEJBHTTP-119] Naming: transform EJB affinities on naming invocations

### DIFF
--- a/naming/pom.xml
+++ b/naming/pom.xml
@@ -47,6 +47,10 @@
             <artifactId>wildfly-naming-client</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.jboss</groupId>
+            <artifactId>jboss-ejb-client</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging-processor</artifactId>
             <scope>provided</scope>

--- a/naming/src/main/java/org/wildfly/httpclient/naming/HttpNamingServerObjectResolver.java
+++ b/naming/src/main/java/org/wildfly/httpclient/naming/HttpNamingServerObjectResolver.java
@@ -1,0 +1,58 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.httpclient.naming;
+
+import io.undertow.server.HttpServerExchange;
+import org.jboss.ejb.client.Affinity;
+import org.jboss.ejb.client.URIAffinity;
+import org.jboss.marshalling.ObjectResolver;
+
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public final class HttpNamingServerObjectResolver implements ObjectResolver {
+    private URIAffinity selfNodeAffinity;
+
+    public HttpNamingServerObjectResolver(HttpServerExchange exchange) {
+        try {
+            selfNodeAffinity = createLocalURIAffinity(exchange);
+        } catch (URISyntaxException ignored) {
+        }
+    }
+
+    private URIAffinity createLocalURIAffinity(HttpServerExchange exchange) throws URISyntaxException {
+        InetSocketAddress localAddress = (InetSocketAddress) exchange.getConnection().getLocalAddress();
+        StringBuilder uriStringBuilder = new StringBuilder();
+        uriStringBuilder.append(exchange.getRequestScheme()).append("://")
+                .append(localAddress.getHostName()).append(":").append(localAddress.getPort())
+                .append("/wildfly-services");
+        return new URIAffinity(new URI(uriStringBuilder.toString()));
+    }
+
+    public Object readResolve(final Object replacement) {
+        return replacement;
+    }
+
+    public Object writeReplace(final Object original) {
+        if (original == Affinity.LOCAL && selfNodeAffinity != null) {
+            return selfNodeAffinity;
+        }
+        return original;
+    }
+}

--- a/naming/src/main/java/org/wildfly/httpclient/naming/HttpRemoteNamingService.java
+++ b/naming/src/main/java/org/wildfly/httpclient/naming/HttpRemoteNamingService.java
@@ -255,7 +255,8 @@ public class HttpRemoteNamingService {
 
     private void doMarshall(HttpServerExchange exchange, Object result) throws IOException {
         exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, VALUE.toString());
-        Marshaller marshaller = httpServiceConfig.getHttpMarshallerFactory(exchange).createMarshaller();
+        HttpNamingServerObjectResolver resolver = new HttpNamingServerObjectResolver(exchange);
+        Marshaller marshaller = httpServiceConfig.getHttpMarshallerFactory(exchange).createMarshaller(resolver);
         marshaller.start(new NoFlushByteOutput(Marshalling.createByteOutput(exchange.getOutputStream())));
         marshaller.writeObject(result);
         marshaller.finish();


### PR DESCRIPTION
https://issues.redhat.com/browse/WEJBHTTP-119

This is a hacky fix that is suppose to make sure http naming invocations are running properly. @fl4via @ropalka could you please review? Is there some more clever way to assemble local URI before sending it to the client?