### PR TITLE
[WEJBHTTP-137] Make only jboss.returned.keys visible in post invocation processing

### DIFF
--- a/ejb/src/main/java/org/wildfly/httpclient/ejb/HttpEJBReceiver.java
+++ b/ejb/src/main/java/org/wildfly/httpclient/ejb/HttpEJBReceiver.java
@@ -37,6 +37,7 @@ import java.security.PrivilegedAction;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -94,6 +95,13 @@ class HttpEJBReceiver extends EJBReceiver {
 
     static {
         AUTH_CONTEXT_CLIENT = AccessController.doPrivileged((PrivilegedAction<AuthenticationContextConfigurationClient>) () -> new AuthenticationContextConfigurationClient());
+    }
+
+    private static final Set<String> WELL_KNOWN_KEYS;
+
+    static {
+        WELL_KNOWN_KEYS = new HashSet<>();
+        WELL_KNOWN_KEYS.add("jboss.source.address");
     }
 
     private final AttachmentKey<EjbContextData> EJB_CONTEXT_DATA = AttachmentKey.create(EjbContextData.class);
@@ -221,13 +229,15 @@ class HttpEJBReceiver extends EJBReceiver {
                                     // WEJBHTTP-83 - remove jboss.returned.keys values from the local context data, so that after unmarshalling the response, we have the correct ContextData
                                     Set<String> returnedContextDataKeys = (Set<String>) clientInvocationContext.getContextData().get(EJBClientInvocationContext.RETURNED_CONTEXT_DATA_KEY);
                                     if(returnedContextDataKeys != null) {
-                                        clientInvocationContext.getContextData().keySet().removeAll(returnedContextDataKeys);
+                                        clientInvocationContext.getContextData().keySet().removeIf(k -> (!k.equals(EJBClientInvocationContext.RETURNED_CONTEXT_DATA_KEY)));
                                     }
+                                    Set<String> returnedKeys =  (Set<String>) clientInvocationContext.getContextData().get(EJBClientInvocationContext.RETURNED_CONTEXT_DATA_KEY);
 
                                     // If there are any attachments, add them to the client invocation's context data
                                     if (attachments != null) {
                                         for (Map.Entry<String, Object> entry : attachments.entrySet()) {
-                                            if (entry.getValue() != null) {
+                                            if (entry.getValue() != null &&
+                                                    ((returnedKeys != null && returnedKeys.contains(entry.getKey())) || WELL_KNOWN_KEYS.contains(entry.getKey()))) {
                                                 clientInvocationContext.getContextData().put(entry.getKey(), entry.getValue());
                                             }
                                         }


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WEJBHTTP-137

This is a back port of #183 to `1.1` branch