### PR TITLE
Modified interoperability protocol

### DIFF
--- a/common/src/main/java/org/wildfly/httpclient/common/EENamespaceInteroperability.java
+++ b/common/src/main/java/org/wildfly/httpclient/common/EENamespaceInteroperability.java
@@ -124,14 +124,14 @@ final class EENamespaceInteroperability {
         return createProtocolVersionHttpHandler(new EENamespaceInteroperabilityHandler(multiVersionedProtocolHandlers[0]), versionedJakartaNamespaceHandlers);
     }
 
-    static HttpHandler createProtocolVersionHttpHandler(HttpHandler interoperabilityHandler, HttpHandler latestProtocolHandler) {
+    private static HttpHandler createProtocolVersionHttpHandler(HttpHandler interoperabilityHandler, HttpHandler latestProtocolHandler) {
         final PathHandler versionPathHandler = new PathHandler();
         versionPathHandler.addPrefixPath(VERSION_ONE_PATH, interoperabilityHandler);
         versionPathHandler.addPrefixPath(VERSION_TWO_PATH, latestProtocolHandler);
         return versionPathHandler;
     }
 
-    static HttpHandler createProtocolVersionHttpHandler(HttpHandler interoperabilityHandler, HttpHandler... versionedProtocolHandlers) {
+    private static HttpHandler createProtocolVersionHttpHandler(HttpHandler interoperabilityHandler, HttpHandler... versionedProtocolHandlers) {
         final PathHandler versionPathHandler = new PathHandler();
         versionPathHandler.addPrefixPath(VERSION_ONE_PATH, interoperabilityHandler);
         int version = 2;

--- a/common/src/main/java/org/wildfly/httpclient/common/HttpClientMessages.java
+++ b/common/src/main/java/org/wildfly/httpclient/common/HttpClientMessages.java
@@ -78,4 +78,6 @@ interface HttpClientMessages extends BasicLogger {
     @Message(id = 14, value = "JavaEE to JakartaEE backward compatibility layer have been installed")
     void javaeeToJakartaeeBackwardCompatibilityLayerInstalled();
 
+    @Message(id = 15, value = "Client protocol version %s is strictly greater than server protocol version %s")
+    IOException protocolVersionIncompatibility(int clientVersion, int serverVersion);
 }

--- a/common/src/main/java/org/wildfly/httpclient/common/HttpServiceConfig.java
+++ b/common/src/main/java/org/wildfly/httpclient/common/HttpServiceConfig.java
@@ -20,8 +20,6 @@ package org.wildfly.httpclient.common;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
 
-import java.util.function.Function;
-
 /**
  * Mode configuration for http services.
  * <p>
@@ -30,14 +28,12 @@ import java.util.function.Function;
  *
  * @author Flavia Rainone
  */
-public enum HttpServiceConfig {
+public class HttpServiceConfig {
 
     /**
      * Default configuration. Used by both EE namespace interoperable and non-interoperable servers
      */
-    DEFAULT (EENamespaceInteroperability::createInteroperabilityHandler,
-            EENamespaceInteroperability::createInteroperabilityHandler,
-            EENamespaceInteroperability.getHttpMarshallerFactoryProvider());
+    private static final HttpServiceConfig INSTANCE = new HttpServiceConfig (EENamespaceInteroperability.getHttpMarshallerFactoryProvider());
 
     /**
      * Returns the default configuration.
@@ -45,16 +41,12 @@ public enum HttpServiceConfig {
      * @return the configuration for http services
      */
     public static HttpServiceConfig getInstance() {
-        return DEFAULT;
+        return INSTANCE;
     }
 
-    private final Function<HttpHandler, HttpHandler> singleHandlerWrapper;
-    private final Function<HttpHandler[], HttpHandler> multiVersionedHandlerWrapper;
     private final HttpMarshallerFactoryProvider marshallerFactoryProvider;
 
-    HttpServiceConfig(Function<HttpHandler, HttpHandler> singleHandlerWrapper, Function<HttpHandler[], HttpHandler> multiVersionedHandlerWrapper, HttpMarshallerFactoryProvider marshallerFactoryProvider) {
-        this.singleHandlerWrapper = singleHandlerWrapper;
-        this.multiVersionedHandlerWrapper = multiVersionedHandlerWrapper;
+    HttpServiceConfig(HttpMarshallerFactoryProvider marshallerFactoryProvider) {
         this.marshallerFactoryProvider = marshallerFactoryProvider;
     }
 
@@ -75,7 +67,7 @@ public enum HttpServiceConfig {
      *         before invoking the inner {@code handler}.
      */
     public HttpHandler wrap(HttpHandler handler) {
-        return singleHandlerWrapper.apply(handler);
+        return EENamespaceInteroperability.createInteroperabilityHandler(handler);
     }
 
     /**
@@ -101,7 +93,7 @@ public enum HttpServiceConfig {
      *         versioning to invoke the appropriate handler
      */
     public HttpHandler wrap(HttpHandler... multiVersionedHandlers) {
-        return multiVersionedHandlerWrapper.apply(multiVersionedHandlers);
+        return EENamespaceInteroperability.createInteroperabilityHandler(multiVersionedHandlers);
     }
 
     /**

--- a/common/src/main/java/org/wildfly/httpclient/common/HttpServiceConfig.java
+++ b/common/src/main/java/org/wildfly/httpclient/common/HttpServiceConfig.java
@@ -35,7 +35,9 @@ public enum HttpServiceConfig {
     /**
      * Default configuration. Used by both EE namespace interoperable and non-interoperable servers
      */
-    DEFAULT (EENamespaceInteroperability::createInteroperabilityHandler, EENamespaceInteroperability.getHttpMarshallerFactoryProvider());
+    DEFAULT (EENamespaceInteroperability::createInteroperabilityHandler,
+            EENamespaceInteroperability::createInteroperabilityHandler,
+            EENamespaceInteroperability.getHttpMarshallerFactoryProvider());
 
     /**
      * Returns the default configuration.
@@ -46,26 +48,60 @@ public enum HttpServiceConfig {
         return DEFAULT;
     }
 
-    private final Function<HttpHandler, HttpHandler> handlerWrapper;
+    private final Function<HttpHandler, HttpHandler> singleHandlerWrapper;
+    private final Function<HttpHandler[], HttpHandler> multiVersionedHandlerWrapper;
     private final HttpMarshallerFactoryProvider marshallerFactoryProvider;
 
-    HttpServiceConfig(Function<HttpHandler, HttpHandler> handlerWrapper, HttpMarshallerFactoryProvider marshallerFactoryProvider) {
-        this.handlerWrapper = handlerWrapper;
+    HttpServiceConfig(Function<HttpHandler, HttpHandler> singleHandlerWrapper, Function<HttpHandler[], HttpHandler> multiVersionedHandlerWrapper, HttpMarshallerFactoryProvider marshallerFactoryProvider) {
+        this.singleHandlerWrapper = singleHandlerWrapper;
+        this.multiVersionedHandlerWrapper = multiVersionedHandlerWrapper;
         this.marshallerFactoryProvider = marshallerFactoryProvider;
     }
 
     /**
      * Wraps the http service handler. Should be applied to all http handlers configured by
      * a http service.
+     * <br>
+     * The resulting handler is compatible with EE namespace interoperability and accepts
+     * {@code javax} namespace requests at the path prefix {@code "/v1"}, while {@code jakarta}
+     * namespace requests are received at the path prefix {@code "/v2"}. Both requests are
+     * forwarded to {@code handler}, but in case of {@code "/v1"} the {@code javax} namespace
+     * is converted to {@code jakarta}.
      *
      * @param handler responsible for handling the HTTP service requests directed to a specific
-     *                URI
+     *                URI. This handler must operate on {@code jakarta} namespace.
      * @return the HttpHandler that should be provided to Undertow and associated with the HTTP
      *         service URI. The resulting handler is a wrapper that will add any necessary actions
      *         before invoking the inner {@code handler}.
      */
     public HttpHandler wrap(HttpHandler handler) {
-        return handlerWrapper.apply(handler);
+        return singleHandlerWrapper.apply(handler);
+    }
+
+    /**
+     * Wraps a multi-version series of handlers. Each handler represents a version of the same operation
+     * provided by a HTTP service.
+     * <br>
+     * The resulting handler receives {@code javax} namespace requests at the path prefix {@code "/v1"},
+     * translates them to {@code jakarta namespace} and forwards them to {@code multiVersionedHandlers[0]}.
+     * The subsequent handlers in the {@code multiVersionedHandlers} array are mapped to path {@code "/v2"},
+     * {@code "/v3"} and so on.
+     * <br>
+     * Use this method when the http service supports more than one version of an HTTP Handler. This will be
+     * the case as http handlers evolve to incorporate new features and fixes that change the particular
+     * protocol format used by the HTTP handler for the specific operation it represents.
+     *
+     * @param multiVersionedHandlers responsible for handling the HTTP service requests directed to a specific
+     *                               URI. The handlers must be in crescent protocol number order, i.e., in the
+     *                               sequence corresponding to {@code "/v2"}, {@code "/v3}, {@code "/v4"}. All
+     *                               the handlers must be compatible with requests in the Jakarta namespace.
+     *
+     * @return the HttpHandler that should be provided to Undertow and associated with the HTTP
+     *         service URI. The resulting handler is a wrapper that will take care of protocol
+     *         versioning to invoke the appropriate handler
+     */
+    public HttpHandler wrap(HttpHandler... multiVersionedHandlers) {
+        return multiVersionedHandlerWrapper.apply(multiVersionedHandlers);
     }
 
     /**

--- a/common/src/main/java/org/wildfly/httpclient/common/HttpTargetContext.java
+++ b/common/src/main/java/org/wildfly/httpclient/common/HttpTargetContext.java
@@ -108,6 +108,7 @@ public class HttpTargetContext extends AbstractAttachable {
 
     void init() {
         if (eagerlyAcquireAffinity) {
+            HttpClientMessages.MESSAGES.debugf("Eagerly acquiring affinity");
             acquireAffinitiy(AUTH_CONTEXT_CLIENT.getAuthenticationConfiguration(uri, AuthenticationContext.captureCurrent()));
         }
     }
@@ -130,7 +131,8 @@ public class HttpTargetContext extends AbstractAttachable {
     private void acquireSessionAffinity(CountDownLatch latch, AuthenticationConfiguration authenticationConfiguration) {
         ClientRequest clientRequest = new ClientRequest();
         clientRequest.setMethod(Methods.GET);
-        clientRequest.setPath(uri.getPath() + "/common/v1/affinity");
+        // the request version required is determined by the HttpConnectionPool
+        clientRequest.setPath(uri.getPath() + "/common" + Protocol.VERSION_PATH + getProtocolVersion() + "/affinity");
         AuthenticationContext context = AuthenticationContext.captureCurrent();
         SSLContext sslContext;
         try {

--- a/common/src/test/java/org/wildfly/httpclient/common/AcquireAffinityTestCase.java
+++ b/common/src/test/java/org/wildfly/httpclient/common/AcquireAffinityTestCase.java
@@ -36,7 +36,9 @@ public class AcquireAffinityTestCase {
 
     @Test
     public void testAcquireAffinity() throws URISyntaxException {
-        HTTPTestServer.registerServicesHandler("common/v1/affinity", exchange -> exchange.setResponseCookie(new CookieImpl("JSESSIONID", "foo")));
+        // when in interop mode, the first invocation will always be /v1
+        HTTPTestServer.registerServicesHandler("/common/v1/affinity", exchange -> exchange.setResponseCookie(new CookieImpl("JSESSIONID", "foo")));
+        HTTPTestServer.registerServicesHandler("/common/v2/affinity", exchange -> exchange.setResponseCookie(new CookieImpl("JSESSIONID", "foo")));
 
         AuthenticationContext cc = AuthenticationContext.captureCurrent();
         HttpTargetContext context = WildflyHttpContext.getCurrent().getTargetContext(new URI(HTTPTestServer.getDefaultServerURL()));

--- a/common/src/test/java/org/wildfly/httpclient/common/AuthenticationExceptionTestCase.java
+++ b/common/src/test/java/org/wildfly/httpclient/common/AuthenticationExceptionTestCase.java
@@ -17,6 +17,7 @@ import io.undertow.util.Headers;
 import io.undertow.util.Methods;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.security.auth.client.AuthenticationConfiguration;

--- a/common/src/test/java/org/wildfly/httpclient/common/HTTPTestServer.java
+++ b/common/src/test/java/org/wildfly/httpclient/common/HTTPTestServer.java
@@ -29,6 +29,7 @@ import io.undertow.server.HttpHandler;
 import io.undertow.server.handlers.BlockingHandler;
 import io.undertow.server.handlers.CanonicalPathHandler;
 import io.undertow.server.handlers.PathHandler;
+import io.undertow.server.handlers.RequestDumpingHandler;
 import io.undertow.server.handlers.error.SimpleErrorPageHandler;
 import io.undertow.util.NetworkUtils;
 import org.junit.runner.Description;
@@ -274,6 +275,7 @@ public class HTTPTestServer extends BlockJUnit4ClassRunner {
         root = new AuthenticationCallHandler(root);
         root = new SimpleErrorPageHandler(root);
         root = new CanonicalPathHandler(root);
+        root = new RequestDumpingHandler(root);
         return root;
     }
 

--- a/ejb/src/main/java/org/wildfly/httpclient/ejb/HttpDiscoveryHandler.java
+++ b/ejb/src/main/java/org/wildfly/httpclient/ejb/HttpDiscoveryHandler.java
@@ -48,7 +48,7 @@ public class HttpDiscoveryHandler extends RemoteHTTPHandler {
 
     @Deprecated
     public HttpDiscoveryHandler(ExecutorService executorService, Association association) {
-        this (executorService, association, HttpServiceConfig.DEFAULT);
+        this (executorService, association, HttpServiceConfig.getInstance());
     }
 
     public HttpDiscoveryHandler(ExecutorService executorService, Association association, HttpServiceConfig httpServiceConfig) {

--- a/ejb/src/test/java/org/wildfly/httpclient/ejb/AsyncInvocationTestCase.java
+++ b/ejb/src/test/java/org/wildfly/httpclient/ejb/AsyncInvocationTestCase.java
@@ -24,6 +24,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+
+import io.undertow.server.handlers.CookieImpl;
 import jakarta.ejb.ApplicationException;
 
 import org.jboss.ejb.client.EJBClient;
@@ -34,6 +36,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import io.undertow.util.Headers;
+import org.wildfly.httpclient.common.HTTPTestServer;
 
 /**
  * @author Stuart Douglas
@@ -46,7 +49,9 @@ public class AsyncInvocationTestCase {
 
     @Before
     public void before() {
-        EJBTestServer.registerServicesHandler("common/v1/affinity", httpServerExchange -> httpServerExchange.getResponseHeaders().put(Headers.SET_COOKIE, "JSESSIONID=" + EJBTestServer.INITIAL_SESSION_AFFINITY));
+        // when in interop mode, the first invocation will always be /v1
+        HTTPTestServer.registerServicesHandler("/common/v1/affinity", exchange -> exchange.setResponseCookie(new CookieImpl("JSESSIONID", "foo")));
+        HTTPTestServer.registerServicesHandler("/common/v2/affinity", exchange -> exchange.setResponseCookie(new CookieImpl("JSESSIONID", "foo")));
     }
 
     @Test

--- a/ejb/src/test/java/org/wildfly/httpclient/ejb/EJBTestServer.java
+++ b/ejb/src/test/java/org/wildfly/httpclient/ejb/EJBTestServer.java
@@ -66,6 +66,20 @@ public class EJBTestServer extends HTTPTestServer {
         EJBTestServer.handler = handler;
     }
 
+    /**
+     * A method to register the EJB/HTTP services handlers, which perform the following functions on the server side:
+     * - receiveInvocationRequest
+     * - receiveSessionOpenRequest
+     * - registerClusterTopologyListener
+     * - registerModuleAvailabilityListener
+     * These operations are performed in the context of an Association, responsible for part processing of the request.
+     *
+     * The invocation processing service requires two additional parts:
+     * - a handler, TestEJBHandler, which represents the invocation processing and returns the invocation result
+     * - an output, TestEJBOutput, holding the session affinity of the response
+     *
+     * @param servicesHandler
+     */
     @Override
     protected void registerPaths(PathHandler servicesHandler) {
         servicesHandler.addPrefixPath("/ejb", new EjbHttpService(new Association() {

--- a/pom.xml
+++ b/pom.xml
@@ -394,7 +394,7 @@
                             <goals><goal>test</goal></goals>
                             <configuration>
                                 <systemPropertyVariables>
-                                    <org.wildfly.ee.interoperable>true</org.wildfly.ee.interoperable>
+                                    <org.wildfly.ee.namespace.interop>true</org.wildfly.ee.namespace.interop>
                                 </systemPropertyVariables>
                                 <reportsDirectory>${project.build.directory}/surefire-ee-interoperable-reports</reportsDirectory>
                             </configuration>


### PR DESCRIPTION
This is a modification of the PR for https://issues.redhat.com/browse/WEJBHTTP-106 which:
- introduces an HttpHandler which allows decoupling the two key functions of the interoperability protocol:
(1) determining the protocol version to be used via a handshake between client and server on the first request
(2) sending the correct protocl ersion to the server via the request context path 
- fixes the problem of the first request in a connection pool being returned by a component other than the /ejb, /naming or /txn service handlers which breaks the protocol handshake