### PR TITLE
[WEJBHTTP-138] Enforce use of --release 8 of 1.1 branch

### DIFF
--- a/common/build-release-8
+++ b/common/build-release-8
@@ -1,0 +1,1 @@
+This file is needed to enable --release 8 when JDK is higher than 8.

--- a/ejb/build-release-8
+++ b/ejb/build-release-8
@@ -1,0 +1,1 @@
+This file is needed to enable --release 8 when JDK is higher than 8.

--- a/naming/build-release-8
+++ b/naming/build-release-8
@@ -1,0 +1,1 @@
+This file is needed to enable --release 8 when JDK is higher than 8.

--- a/transaction/build-release-8
+++ b/transaction/build-release-8
@@ -1,0 +1,1 @@
+This file is needed to enable --release 8 when JDK is higher than 8.


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WEJBHTTP-138

This is only needed for `1.1` branch