### PR TITLE
 [WEJBHTTP-147] CI Add integration testing to CI script

### DIFF
--- a/.github/workflows/integration.sh
+++ b/.github/workflows/integration.sh
@@ -1,0 +1,11 @@
+echo "INTEGRATION TESTS"
+
+WILDFLY_HTTP_REPOSITORY=$1
+WILDFLY_HTTP_BRANCH=$2
+
+git clone --depth=1 https://github.com/wildfly/ejb-client-testsuite
+
+cd ejb-client-testsuite
+
+mvn -B -ntp package -DspecificModule=prepare -Dhttp.client.repository=${WILDFLY_HTTP_REPOSITORY} -Dhttp.client.branch=${WILDFLY_HTTP_BRANCH}
+mvn -B -ntp dependency:tree clean verify --fail-at-end -Dmaven.test.redirectTestOutputToFile=true

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,32 @@
+name: Wildfly EJB Client CI Integration Tests
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  build-test-matrix:
+    name: ${{ matrix.jdk-distribution}}-${{ matrix.jdk-version }}-${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        jdk-distribution: [temurin]
+        jdk-version: [17]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK ${{ matrix.jdk-distribution }} ${{ matrix.jdk-version }}
+        uses: actions/setup-java@v4
+        with:
+          distribution: ${{ matrix.jdk-distribution }}
+          java-version: ${{ matrix.jdk-version }}
+          cache: 'maven'
+      - name: Run Tests
+        run: bash ${GITHUB_WORKSPACE}/.github/workflows/integration.sh ${{github.event.pull_request.head.repo.html_url}} ${{github.head_ref}}
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: surefire-${{ matrix.jdk-distribution }}-${{ matrix.jdk-version }}-${{ matrix.os }}
+          path: '**/surefire-reports/*.txt'

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -1,7 +1,7 @@
 # This workflow will build a Java project with Maven
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
-name: WildFly Http Client CI
+name: WildFly Http Client CI Unit Tests
 
 on:
   pull_request:


### PR DESCRIPTION
Jira tracker: https://issues.redhat.com/browse/WEJBHTTP-147

Add integration tests to upstream CI for https://github.com/wildfly/ejb-client-testsuite

Similar like:

* [EJBCLIENT-505](https://issues.redhat.com/browse/EJBCLIENT-505)
* https://github.com/wildfly/jboss-ejb-client/pull/644

This PR is for branch 2.0, because it is used in WF. See more about main branch in https://github.com/wildfly/wildfly-http-client/pull/235